### PR TITLE
make notify-send optional

### DIFF
--- a/data_types/src/internal.rs
+++ b/data_types/src/internal.rs
@@ -289,7 +289,9 @@ impl Video {
     pub fn open(&self) {
         // open with mpv
         let link = &self.link;
-        Command::new("notify-send").arg("Open video").arg(&self.title).stderr(Stdio::null()).spawn().expect("failed");
+        if Command::new("notify-send").arg("Open video").arg(&self.title).stderr(Stdio::null()).spawn().is_err() {
+          println!("notify-send failed");
+        }
         Command::new("setsid").arg("-f").arg("umpv").arg(link).stderr(Stdio::null()).spawn().expect("umpv stating failed");
     }
     #[allow(dead_code)]


### PR DESCRIPTION
i dont have dbus or notify-send. i tried making a dummy shell script called notify-send but got some exec error.

this seems a better solution